### PR TITLE
Offset account for optional date

### DIFF
--- a/lib/offset.rb
+++ b/lib/offset.rb
@@ -1,10 +1,15 @@
+require 'date'
+
 class Offset
   attr_reader :date
-  def initialize(date)
+  def initialize(date = nil)
     @date = date
   end
 
   def square
+    if @date == nil
+      @date = Time.now.strftime("%d%m%y").to_i
+    end
     (@date.to_i * @date.to_i)
   end
 

--- a/test/offset_test.rb
+++ b/test/offset_test.rb
@@ -4,22 +4,27 @@ require './lib/offset'
 
 class OffsetTest < Minitest::Test
   def test_offset_exists
-    offset = Offset.new("011020")
+    offset = Offset.new("010419")
     assert_instance_of Offset, offset
   end
 
   def test_offset_has_a_date
-    offset = Offset.new("011020")
-    assert_equal "011020", offset.date
+    offset = Offset.new("010419")
+    assert_equal "010419", offset.date
   end
 
   def test_can_square_the_date
-    offset = Offset.new("011020")
-    assert_equal 121440400, offset.square
+    offset = Offset.new("010419")
+    assert_equal 108555561, offset.square
   end
 
   def test_can_get_last_for_digits_of_squared_date
-    offset = Offset.new("011020")
-    assert_equal ["0", "4", "0", "0"], offset.last_four
+    offset = Offset.new("010419")
+    assert_equal ["5", "5", "6", "1"], offset.last_four
+  end
+
+  def test_do_offset_calculation_if_date_is_not_provided
+    offset = Offset.new
+    assert_equal ["4", "4", "0", "0"], offset.last_four
   end
 end


### PR DESCRIPTION
Make date argument optional when offset is initialized and edit square method and tests to account for that